### PR TITLE
Add pagination to student gallery + CSS updates

### DIFF
--- a/app/partners/students/page.js
+++ b/app/partners/students/page.js
@@ -226,13 +226,7 @@ export default function () {
         <Filters setFilterData={setFilterData} />
       </Grid>
 
-      <Grid
-        templateRows="repeat(2, 1fr)"
-        templateColumns="repeat(3, 1fr)"
-        gapX="20"
-        gapY="10"
-        pb="16"
-      >
+      <Grid templateRows="repeat(2, 1fr)" templateColumns="repeat(3, 1fr)" gap="20" pb="16">
         {students.slice((page - 1) * pageSize, page * pageSize).map((student) => (
           <Student key={student.id} fields={student.fields} />
         ))}

--- a/components/gallery/SelectFilter.jsx
+++ b/components/gallery/SelectFilter.jsx
@@ -19,7 +19,7 @@ export default function SelectFilter({ title, options, placeholder, multiple, on
       onValueChange={onValueChange}
     >
       <SelectLabel>{title}</SelectLabel>
-      <SelectTrigger clearable={true} className="border-1 rounded-lg">
+      <SelectTrigger clearable={true} className="border rounded-lg">
         <SelectValueText placeholder={placeholder} className="px-2" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
Adds a ChakraUI Pagination component to allow the user to view all results that match the query. It doesn't match the design 1:1 (missing arrow icon, some styling differences, and Previous/Next text).

Additionally the select filter borders have been restored and the gap between student records has been made horizontally and vertically identical as requested.